### PR TITLE
Update CI workflows to use macos-15 runner

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: Build and Test
-    runs-on: macos-13
+    runs-on: macos-15
     env:
       PACKAGE_NAME: Stubby
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-13
+    runs-on: macos-15
     env:
       DOCUMENTATION_PATH: docs
     steps:


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflows to use macOS 15 instead of macOS 13.

### What changed?

Modified both the `build-and-test.yml` and `documentation.yml` workflow files to use `macos-15` as the runner instead of `macos-13`.

### How to test?

Verify that the GitHub Actions workflows run successfully on the new macOS 15 runner by:
1. Checking the workflow runs after merging this PR
2. Confirming that both build/test and documentation generation complete without errors

### Why make this change?

Upgrading to the latest macOS runner version ensures we're using the most up-to-date environment for our CI/CD pipelines. This helps maintain compatibility with the latest development tools and dependencies, and prepares our workflows for future requirements.