### PR TITLE
Add Swift macros for stubbing URL responses

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,9 +1,18 @@
 {
   "pins" : [
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
         "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
         "version" : "1.4.5"
@@ -16,6 +25,42 @@
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
+      "state" : {
+        "revision" : "9ab11325daa51c7c5c10fcf16c92bac906717c7e",
+        "version" : "0.6.4"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
+        "version" : "1.18.7"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
+        "version" : "1.7.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,30 +1,56 @@
 // swift-tools-version: 5.9
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import CompilerPluginSupport
 import PackageDescription
 
 let package = Package(
   name: "Stubby",
   platforms: [
-    .macOS(.v10_13),
-    .iOS(.v12),
+    .iOS(.v13),
+    .macOS(.v10_15),
   ],
   products: [
     .library(name: "Stubby", targets: ["Stubby"]),
+    .library(name: "StubbyMacros", targets: ["StubbyMacros"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-docc-plugin", .upToNextMajor(from: "1.4.5")),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", .upToNextMajor(from: "0.6.4")),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", .upToNextMajor(from: "1.4.5")),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"600.0.0"),
   ],
   targets: [
     .target(
-      name: "Stubby",
-      dependencies: []
+      name: "Stubby"
     ),
     .testTarget(
       name: "StubbyTests",
       dependencies: [
-        .target(name: "Stubby"),
+        "Stubby",
+        "StubbyMacros",
+        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
       ]
     ),
+    .target(
+      name: "StubbyMacros",
+      dependencies: [
+        "StubbyMacrosPlugin",
+      ]
+    ),
+    .macro(
+      name: "StubbyMacrosPlugin",
+      dependencies: [
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
+      name: "StubbyMacrosPluginTests",
+      dependencies: [
+        "StubbyMacros",
+        "StubbyMacrosPlugin",
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+      ]
+    )
   ]
 )

--- a/Sources/StubbyMacros/Macros.swift
+++ b/Sources/StubbyMacros/Macros.swift
@@ -1,0 +1,20 @@
+// Created by Brad Bergeron on 9/22/23.
+
+import Foundation
+import Stubby
+
+@freestanding(declaration)
+public macro Stub(
+  _ urlString: StaticString,
+  response: (URLRequest) throws -> Result<StubbyResponse, Error>)
+  = #externalMacro(module: "StubbyMacrosPlugin", type: "StubMacro")
+
+/*
+#Stub("https://github.com/bdbergeron/Stubby") { request in
+ try .success(StubbyResponse(data: XCTUnwrap("Hello, world!".data(using: .utf8)), for: XCTUnwrap(request.url)))
+}
+
+#Stub("https://github.com") { _ in
+  .failure(URLError(.unsupportedURL))
+}
+*/

--- a/Sources/StubbyMacrosPlugin/Plugins.swift
+++ b/Sources/StubbyMacrosPlugin/Plugins.swift
@@ -1,0 +1,11 @@
+// Created by Brad Bergeron on 9/22/23.
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct StubbyMacrosPlugin: CompilerPlugin {
+  let providingMacros: [Macro.Type] = [
+    StubMacro.self,
+  ]
+}

--- a/Sources/StubbyMacrosPlugin/StubMacro.swift
+++ b/Sources/StubbyMacrosPlugin/StubMacro.swift
@@ -11,10 +11,8 @@ import SwiftSyntaxMacros
 public struct StubMacro: DeclarationMacro {
   public static func expansion<Node: FreestandingMacroExpansionSyntax, Context: MacroExpansionContext>(
     of node: Node,
-    in context: Context)
-    throws
-    -> [DeclSyntax]
-  {
+    in context: Context
+  ) throws -> [DeclSyntax] {
     guard
       let stubbedURLString = node.arguments.first?.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue,
       let _ = URL(string: stubbedURLString)
@@ -45,16 +43,16 @@ public struct StubMacro: DeclarationMacro {
             parameterClause: FunctionParameterClauseSyntax {
               FunctionParameterSyntax(
                 firstName: .identifier("request"),
-                type: IdentifierTypeSyntax(name: .identifier("URLRequest")))
+                type: IdentifierTypeSyntax(name: .identifier("URLRequest"))
+              )
             },
-            returnClause: ReturnClauseSyntax(type: IdentifierTypeSyntax(name: .identifier("Bool")))))
-        {
-          CodeBlockItemListSyntax {
+            returnClause: ReturnClauseSyntax(type: IdentifierTypeSyntax(name: .identifier("Bool")))
+          )
+        ) {
             InfixOperatorExprSyntax(
               leftOperand: MemberAccessExprSyntax(base: DeclReferenceExprSyntax(baseName: .identifier("request")), name: .identifier("url")),
               operator: BinaryOperatorExprSyntax(operator: .binaryOperator("==")),
               rightOperand: DeclReferenceExprSyntax(baseName: .identifier("url")))
-          }
         }
 
         FunctionDeclSyntax(
@@ -67,7 +65,8 @@ public struct StubMacro: DeclarationMacro {
               FunctionParameterSyntax(
                 firstName: .identifier("for"),
                 secondName: .identifier("request"),
-                type: IdentifierTypeSyntax(name: .identifier("URLRequest")))
+                type: IdentifierTypeSyntax(name: .identifier("URLRequest"))
+              )
             },
             effectSpecifiers: FunctionEffectSpecifiersSyntax(throwsSpecifier: .keyword(.throws)),
             returnClause: ReturnClauseSyntax(
@@ -77,8 +76,12 @@ public struct StubMacro: DeclarationMacro {
                   arguments: GenericArgumentListSyntax {
                     GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("StubbyResponse")))
                     GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("Error")))
-                  })))))
-        {
+                  }
+                )
+              )
+            )
+          )
+        ) {
           response.statements
         }
       })

--- a/Sources/StubbyMacrosPlugin/StubMacro.swift
+++ b/Sources/StubbyMacrosPlugin/StubMacro.swift
@@ -1,0 +1,114 @@
+// Created by Brad Bergeron on 9/22/23.
+
+import Foundation
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+// MARK: - StubMacro
+
+public struct StubMacro: DeclarationMacro {
+  public static func expansion<Node: FreestandingMacroExpansionSyntax, Context: MacroExpansionContext>(
+    of node: Node,
+    in context: Context)
+    throws
+    -> [DeclSyntax]
+  {
+    guard
+      let stubbedURLString = node.arguments.first?.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue,
+      let _ = URL(string: stubbedURLString)
+    else {
+      context.addDiagnostics(from: StubDiagnostic.invalidURL, node: node.arguments)
+      return []
+    }
+
+    guard let response = node.trailingClosure else {
+      context.addDiagnostics(from: StubDiagnostic.missingResponse, node: node)
+      return []
+    }
+
+    let classDecl = StructDeclSyntax(
+      name: context.makeUniqueName("StubResponse"),
+      inheritanceClause: InheritanceClauseSyntax {
+        InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("StubbyResponseProvider")))
+      },
+      memberBlock: MemberBlockSyntax {
+        "static let url = URL(string: \"\(raw: stubbedURLString)\")!"
+
+        FunctionDeclSyntax(
+          modifiers: DeclModifierListSyntax {
+            DeclModifierSyntax(name: .keyword(.static))
+          },
+          name: .identifier("respondsTo"),
+          signature: FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax {
+              FunctionParameterSyntax(
+                firstName: .identifier("request"),
+                type: IdentifierTypeSyntax(name: .identifier("URLRequest")))
+            },
+            returnClause: ReturnClauseSyntax(type: IdentifierTypeSyntax(name: .identifier("Bool")))))
+        {
+          CodeBlockItemListSyntax {
+            InfixOperatorExprSyntax(
+              leftOperand: MemberAccessExprSyntax(base: DeclReferenceExprSyntax(baseName: .identifier("request")), name: .identifier("url")),
+              operator: BinaryOperatorExprSyntax(operator: .binaryOperator("==")),
+              rightOperand: DeclReferenceExprSyntax(baseName: .identifier("url")))
+          }
+        }
+
+        FunctionDeclSyntax(
+          modifiers: DeclModifierListSyntax {
+            DeclModifierSyntax(name: .keyword(.static))
+          },
+          name: .identifier("response"),
+          signature: FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax {
+              FunctionParameterSyntax(
+                firstName: .identifier("for"),
+                secondName: .identifier("request"),
+                type: IdentifierTypeSyntax(name: .identifier("URLRequest")))
+            },
+            effectSpecifiers: FunctionEffectSpecifiersSyntax(throwsSpecifier: .keyword(.throws)),
+            returnClause: ReturnClauseSyntax(
+              type: IdentifierTypeSyntax(
+                name: .identifier("Result"),
+                genericArgumentClause: GenericArgumentClauseSyntax(
+                  arguments: GenericArgumentListSyntax {
+                    GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("StubbyResponse")))
+                    GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("Error")))
+                  })))))
+        {
+          response.statements
+        }
+      })
+
+    return [
+      "#if DEBUG",
+      DeclSyntax(classDecl),
+      "\n#endif",
+    ]
+  }
+}
+
+enum StubDiagnostic: String, Error, DiagnosticMessage {
+  case invalidURL
+  case missingResponse
+
+  var message: String {
+    switch self {
+    case .invalidURL:
+      "#Stub requires a valid URL."
+    case .missingResponse:
+      "#Stub requires a valid response of type `Result<StubbyResponse, Error>`."
+    }
+  }
+
+  var diagnosticID: MessageID {
+    MessageID(domain: "StubMacro", id: rawValue)
+  }
+
+  var severity: DiagnosticSeverity {
+    .error
+  }
+}

--- a/Tests/StubbyMacrosPluginTests/StubMacroTest.swift
+++ b/Tests/StubbyMacrosPluginTests/StubMacroTest.swift
@@ -18,7 +18,8 @@ final class StubMacroTest: XCTestCase {
       #Stub(url: "https://github.com/bdbergeron/Stubby") { request in
         try .success(StubbyResponse(
           data: XCTUnwrap("Hello, world!".data(using: .utf8)),
-          for: XCTUnwrap(request.url)))
+          for: XCTUnwrap(request.url)
+        ))
       }
       """
     } expansion: {
@@ -32,7 +33,8 @@ final class StubMacroTest: XCTestCase {
         static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
           try .success(StubbyResponse(
             data: XCTUnwrap("Hello, world!".data(using: .utf8)),
-            for: XCTUnwrap(request.url)))
+            for: XCTUnwrap(request.url)
+          ))
         }
       }
       #endif
@@ -57,6 +59,74 @@ final class StubMacroTest: XCTestCase {
         }
         static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
           .failure(URLError(.unsupportedURL))
+        }
+      }
+      #endif
+      """
+    }
+  }
+
+  func test_expansion_multipleStubs() throws {
+    assertMacro {
+      """
+      #Stub(url: "https://github.com/bdbergeron/Stubby") { request in
+        try .success(StubbyResponse(
+          data: XCTUnwrap("Hello, world!".data(using: .utf8)),
+          for: XCTUnwrap(request.url)
+        ))
+      }
+      
+      #Stub(url: "https://github.com") { _ in
+        .failure(URLError(.unsupportedURL))
+      }
+      
+      #Stub(url: "https://apple.com") { _ in
+        try .success(StubbyResponse(
+          data: XCTUnwrap("Think different!".data(using: .utf8)),
+          for: XCTUnwrap(request.url)
+        ))
+      }
+      """
+    } expansion: {
+      """
+      #if DEBUG
+      struct __macro_local_12StubResponsefMu_: StubbyResponseProvider {
+        static let url = URL(string: "https://github.com/bdbergeron/Stubby")!
+        static func respondsTo(request: URLRequest) -> Bool {
+          request.url == url
+        }
+        static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
+          try .success(StubbyResponse(
+            data: XCTUnwrap("Hello, world!".data(using: .utf8)),
+            for: XCTUnwrap(request.url)
+          ))
+        }
+      }
+      #endif
+      
+      #if DEBUG
+      struct __macro_local_12StubResponsefMu0_: StubbyResponseProvider {
+        static let url = URL(string: "https://github.com")!
+        static func respondsTo(request: URLRequest) -> Bool {
+          request.url == url
+        }
+        static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
+          .failure(URLError(.unsupportedURL))
+        }
+      }
+      #endif
+      
+      #if DEBUG
+      struct __macro_local_12StubResponsefMu1_: StubbyResponseProvider {
+        static let url = URL(string: "https://apple.com")!
+        static func respondsTo(request: URLRequest) -> Bool {
+          request.url == url
+        }
+        static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
+          try .success(StubbyResponse(
+            data: XCTUnwrap("Think different!".data(using: .utf8)),
+            for: XCTUnwrap(request.url)
+          ))
         }
       }
       #endif

--- a/Tests/StubbyMacrosPluginTests/StubMacroTest.swift
+++ b/Tests/StubbyMacrosPluginTests/StubMacroTest.swift
@@ -1,0 +1,88 @@
+// Created by Brad Bergeron on 10/12/23.
+
+import MacroTesting
+import XCTest
+
+@testable import StubbyMacrosPlugin
+
+final class StubMacroTest: XCTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [StubMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func test_expansion_successResponse() throws {
+    assertMacro {
+      """
+      #Stub(url: "https://github.com/bdbergeron/Stubby") { request in
+        try .success(StubbyResponse(
+          data: XCTUnwrap("Hello, world!".data(using: .utf8)),
+          for: XCTUnwrap(request.url)))
+      }
+      """
+    } expansion: {
+      """
+      #if DEBUG
+      struct __macro_local_12StubResponsefMu_: StubbyResponseProvider {
+        static let url = URL(string: "https://github.com/bdbergeron/Stubby")!
+        static func respondsTo(request: URLRequest) -> Bool {
+          request.url == url
+        }
+        static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
+          try .success(StubbyResponse(
+            data: XCTUnwrap("Hello, world!".data(using: .utf8)),
+            for: XCTUnwrap(request.url)))
+        }
+      }
+      #endif
+      """
+    }
+  }
+
+  func test_expansion_failureResponse() throws {
+    assertMacro {
+      """
+      #Stub(url: "https://github.com/bdbergeron/Stubby") { _ in
+        .failure(URLError(.unsupportedURL))
+      }
+      """
+    } expansion: {
+      """
+      #if DEBUG
+      struct __macro_local_12StubResponsefMu_: StubbyResponseProvider {
+        static let url = URL(string: "https://github.com/bdbergeron/Stubby")!
+        static func respondsTo(request: URLRequest) -> Bool {
+          request.url == url
+        }
+        static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
+          .failure(URLError(.unsupportedURL))
+        }
+      }
+      #endif
+      """
+    }
+  }
+
+  func test_expansionFailsWithInvalidURL() throws {
+    assertMacro {
+      """
+      #Stub("") { request in
+        try .success(StubbyResponse(
+          data: XCTUnwrap("Hello, world!".data(using: .utf8)),
+          for: XCTUnwrap(request.url)))
+      }
+      """
+    } diagnostics: {
+      """
+      #Stub("") { request in
+            ┬─
+            ╰─ 🛑 #Stub requires a valid URL.
+        try .success(StubbyResponse(
+          data: XCTUnwrap("Hello, world!".data(using: .utf8)),
+          for: XCTUnwrap(request.url)))
+      }
+      """
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR

Added Swift macros support to Stubby for easier network request stubbing.

### What changed?

- Added a new `#Stub` macro that generates stub response providers for network requests
- Created new targets for macro support:
  - `StubbyMacros`: Public interface for the macros
  - `StubbyMacrosPlugin`: Implementation of the macros
  - `StubbyMacrosPluginTests`: Tests for the macros
- Updated package dependencies:
  - Added swift-custom-dump, swift-macro-testing, swift-snapshot-testing, swift-syntax, and xctest-dynamic-overlay
  - Updated swift-docc-plugin URL to use swiftlang repository
- Updated minimum platform requirements to iOS 13 and macOS 10.15

### How to test?

1. Use the new `#Stub` macro in your test code:
```swift
#Stub("https://github.com/bdbergeron/Stubby") { request in
  try .success(StubbyResponse(data: XCTUnwrap("Hello, world!".data(using: .utf8)), for: XCTUnwrap(request.url)))
}

// Or for error responses:
#Stub("https://github.com") { _ in
  .failure(URLError(.unsupportedURL))
}
```

2. Run the tests to verify the macro expansion works correctly

### Why make this change?

This change introduces Swift macros to simplify the creation of network stubs for testing. The `#Stub` macro automatically generates the necessary boilerplate code for stubbing network requests, making tests more concise and easier to write. This is especially useful for testing code that interacts with network APIs.