### PR TITLE
Update license and swift-syntax dependency, fix StubbyMacros target

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Brad Bergeron
+Copyright (c) 2023-2025 Brad Bergeron
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", .upToNextMajor(from: "0.6.4")),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", .upToNextMajor(from: "1.4.5")),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"600.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
     .target(
       name: "StubbyMacros",
       dependencies: [
+        "Stubby",
         "StubbyMacrosPlugin",
       ]
     ),

--- a/Sources/StubbyMacros/Macros.swift
+++ b/Sources/StubbyMacros/Macros.swift
@@ -3,18 +3,19 @@
 import Foundation
 import Stubby
 
+
+/*
+ #Stub("https://github.com/bdbergeron/Stubby") { request in
+ try .success(StubbyResponse(data: XCTUnwrap("Hello, world!".data(using: .utf8)), for: XCTUnwrap(request.url)))
+ }
+
+ #Stub("https://github.com") { _ in
+ .failure(URLError(.unsupportedURL))
+ }
+ */
+
 @freestanding(declaration)
 public macro Stub(
   _ urlString: StaticString,
   response: (URLRequest) throws -> Result<StubbyResponse, Error>)
   = #externalMacro(module: "StubbyMacrosPlugin", type: "StubMacro")
-
-/*
-#Stub("https://github.com/bdbergeron/Stubby") { request in
- try .success(StubbyResponse(data: XCTUnwrap("Hello, world!".data(using: .utf8)), for: XCTUnwrap(request.url)))
-}
-
-#Stub("https://github.com") { _ in
-  .failure(URLError(.unsupportedURL))
-}
-*/


### PR DESCRIPTION
### TL;DR

Updated Swift Syntax dependency to version 602.0.0 and made minor project improvements.

### What changed?

- Updated the Swift Syntax dependency from 510.0.3 to 602.0.0 and adjusted the version constraint in Package.swift
- Extended the copyright year range in LICENSE from 2023 to 2023-2025
- Added "Stubby" as a dependency to the "StubbyMacros" target
- Moved the example code comments above the macro declaration for better readability

### How to test?

1. Build the project to ensure it compiles with the updated Swift Syntax version
2. Run existing tests to verify functionality remains intact
3. Verify that the StubbyMacros target correctly references the Stubby dependency

### Why make this change?

The update to Swift Syntax 602.0.0 provides compatibility with newer Swift compiler versions and potentially includes bug fixes and performance improvements. Adding the Stubby dependency to the StubbyMacros target ensures proper dependency resolution. The copyright extension prepares the project for future years of development.