### PR TITLE
Update CI workflows with improved actions and code coverage handling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,14 +30,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      
+
       - name: Build
         run: swift build
-      
+
       - name: Test
         id: test
         run: swift test --enable-code-coverage
-      
+
       - name: Prepare Code Coverage
         id: prepare-codecov-coverage-report
         if: steps.test.outcome == 'success'
@@ -50,7 +50,7 @@ jobs:
           -instr-profile .build/debug/codecov/default.profdata \
           .build/debug/${{ env.PACKAGE_NAME }}PackageTests.xctest/Contents/MacOS/${{ env.PACKAGE_NAME }}PackageTests \
           > info.lcov
-      
+
       - name: Upload coverage to Codecov
         if: steps.prepare-codecov-coverage-report.outcome == 'success'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,25 +19,40 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+  
+env:
+  PACKAGE_NAME: Stubby
 
 jobs:
   build:
     name: Build and Test
     runs-on: macos-15
-    env:
-      PACKAGE_NAME: Stubby
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+      
       - name: Build
         run: swift build
+      
       - name: Test
+        id: test
         run: swift test --enable-code-coverage
+      
       - name: Prepare Code Coverage
-        run: xcrun llvm-cov export --ignore-filename-regex='(Tests)[/\\].*' -format="lcov" .build/debug/${{ env.PACKAGE_NAME }}PackageTests.xctest/Contents/MacOS/${{ env.PACKAGE_NAME }}PackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
+        id: prepare-codecov-coverage-report
+        if: steps.test.outcome == 'success'
+        continue-on-error: true
+        run: |
+          set -o pipefail && \
+          xcrun llvm-cov export \
+          -format="lcov" \
+          --ignore-filename-regex='(Tests)[/\\].*' \
+          -instr-profile .build/debug/codecov/default.profdata \
+          .build/debug/${{ env.PACKAGE_NAME }}PackageTests.xctest/Contents/MacOS/${{ env.PACKAGE_NAME }}PackageTests \
+          > info.lcov
+      
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        if: steps.prepare-codecov-coverage-report.outcome == 'success'
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          fail_ci_if_error: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,12 +42,12 @@ jobs:
           --transform-for-static-hosting \
           --hosting-base-path ${{ github.event.repository.name }} \
           --output-path ${{ env.OUTPUT_PATH }}
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: ${{ env.OUTPUT_PATH }}
-      
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - Sources/**
   workflow_dispatch:
 
 permissions:
@@ -19,25 +17,37 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  OUTPUT_PATH: docs
+  TARGET: Stubby
+
 jobs:
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: macos-15
-    env:
-      DOCUMENTATION_PATH: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
+
       - name: Build documentation
-        run: swift package --allow-writing-to-directory ${{ env.DOCUMENTATION_PATH }} generate-documentation --disable-indexing --include-extended-types --output-path ${{ env.DOCUMENTATION_PATH }} --transform-for-static-hosting
+        run: |
+          swift package --allow-writing-to-directory ${{ env.OUTPUT_PATH }} \
+          generate-documentation --target ${{ env.TARGET }} \
+          --disable-indexing \
+          --transform-for-static-hosting \
+          --hosting-base-path ${{ github.event.repository.name }} \
+          --output-path ${{ env.OUTPUT_PATH }}
+      
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: ${{ env.DOCUMENTATION_PATH }}
+          path: ${{ env.OUTPUT_PATH }}
+      
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflows with improved CI/CD configuration and documentation generation.

### What changed?

- **Build and Test Workflow**:
  - Upgraded GitHub Actions dependencies (checkout v3 → v5, codecov-action v3 → v4)
  - Moved `PACKAGE_NAME` to global environment variables
  - Improved code coverage reporting with better error handling and conditional execution
  - Enhanced readability of commands with multi-line formatting
  - Removed verbose and fail_ci_if_error flags from codecov action

- **Documentation Workflow**:
  - Upgraded GitHub Actions dependencies (checkout v3 → v5, configure-pages v3 → v5, upload-pages-artifact v2 → v4, deploy-pages v2 → v4)
  - Removed path filtering to generate documentation on all main branch pushes
  - Added hosting-base-path parameter to fix documentation links
  - Improved command formatting for better readability
  - Renamed environment variable from `DOCUMENTATION_PATH` to `OUTPUT_PATH` and added `TARGET` variable

### How to test?

1. Verify the build and test workflow runs successfully on a PR
2. Check that code coverage is properly reported to Codecov
3. Merge to main and confirm documentation is generated and deployed correctly
4. Verify documentation links work properly with the new hosting-base-path parameter

### Why make this change?

These updates improve the reliability and maintainability of our CI/CD pipelines by:
- Using the latest versions of GitHub Actions
- Adding better error handling for the code coverage reporting
- Improving documentation generation with proper base path configuration
- Making workflow files more readable with structured formatting
- Standardizing environment variable usage across workflows