### PR TITLE
Add SwiftFormat and SwiftLint configuration files

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,144 @@
+# Exclude checkout directories for common package managers
+--exclude .build
+
+# options
+--swift-version 5.9
+--language-mode 5
+--self remove # redundantSelf
+--import-grouping testable-bottom # sortedImports
+--trailing-commas multi-element-lists # trailingCommas
+--trim-whitespace always # trailingSpace
+--indent 2 #indent
+--ifdef no-indent #indent
+--indent-strings true #indent
+--wrap-arguments before-first # wrapArguments
+--wrap-parameters before-first # wrapArguments
+--wrap-collections before-first # wrapArguments
+--wrap-conditions before-first # wrapArguments
+--wrap-return-type never #wrapArguments
+--wrap-effects never #wrapArguments
+--closing-paren balanced # wrapArguments
+--call-site-paren balanced # wrapArguments
+--wrap-type-aliases before-first # wrapArguments
+--allow-partial-wrapping false # wrapArguments
+--func-attributes prev-line # wrapAttributes
+--computed-var-attributes prev-line # wrapAttributes
+--stored-var-attributes same-line # wrapAttributes
+--complex-attributes prev-line # wrapAttributes
+--type-attributes prev-line # wrapAttributes
+--wrap-ternary before-operators # wrap
+--wrap-string-interpolation preserve # wrap
+--mark-struct-threshold 20 # organizeDeclarations
+--mark-enum-threshold 20 # organizeDeclarations
+--organize-types class,struct,enum,extension,actor,protocol # organizeDeclarations
+--visibility-order beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations
+--type-order nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,swiftUIPropertyWrapper,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
+--sort-swiftui-properties first-appearance-sort #organizeDeclarations
+--type-body-marks remove #organizeDeclarations
+--extension-acl on-declarations # extensionAccessControl
+--pattern-let inline # hoistPatternLet
+--property-types inferred # redundantType, propertyTypes
+--type-blank-lines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
+--empty-braces spaced # emptyBraces
+--ranges preserve # spaceAroundOperators
+--operator-func no-space # spaceAroundOperators
+--some-any disabled # opaqueGenericParameters
+--else-position same-line # elseOnSameLine
+--guard-else next-line # elseOnSameLine
+--single-line-for-each convert # preferForLoop
+--short-optionals always # typeSugar
+--semicolons never # semicolons
+--doc-comments preserve # docComments
+
+# Customized default modifier order to put `override` after access control
+--modifier-order private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),override,final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,unowned(safe),unowned(unsafe),static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix,async # modifierOrder
+
+# We recommend a max width of 100 but _strictly enforce_ a max width of 130
+--max-width 130 # wrap
+
+# rules
+--rules anyObjectProtocol
+--rules blankLinesBetweenScopes
+--rules consecutiveSpaces
+--rules consecutiveBlankLines
+--rules duplicateImports
+--rules extensionAccessControl
+--rules environmentEntry
+--rules hoistPatternLet
+--rules indent
+--rules markTypes
+--rules organizeDeclarations
+--rules redundantParens
+--rules redundantReturn
+--rules redundantSelf
+--rules redundantType
+--rules redundantPattern
+--rules redundantGet
+--rules redundantFileprivate
+--rules redundantRawValues
+--rules redundantEquatable
+--rules sortImports
+--rules sortDeclarations
+--rules strongifiedSelf
+--rules trailingCommas
+--rules trailingSpace
+--rules linebreakAtEndOfFile
+--rules typeSugar
+--rules wrap
+--rules wrapMultilineStatementBraces
+--rules wrapArguments
+--rules wrapAttributes
+--rules wrapEnumCases
+--rules singlePropertyPerLine
+--rules braces
+--rules redundantClosure
+--rules redundantInit
+--rules redundantVoidReturnType
+--rules redundantOptionalBinding
+--rules redundantInternal
+--rules redundantPublic
+--rules redundantProperty
+--rules unusedArguments
+--rules spaceInsideBrackets
+--rules spaceInsideBraces
+--rules spaceAroundBraces
+--rules spaceInsideParens
+--rules spaceAroundParens
+--rules spaceAroundOperators
+--rules enumNamespaces
+--rules blockComments
+--rules docComments
+--rules docCommentsBeforeModifiers
+--rules spaceAroundComments
+--rules spaceInsideComments
+--rules blankLinesAtStartOfScope
+--rules blankLinesAtEndOfScope
+--rules emptyBraces
+--rules andOperator
+--rules opaqueGenericParameters
+--rules genericExtensions
+--rules trailingClosures
+--rules elseOnSameLine
+--rules sortTypealiases
+--rules preferForLoop
+--rules conditionalAssignment
+--rules wrapMultilineConditionalAssignment
+--rules void
+--rules blankLineAfterSwitchCase
+--rules consistentSwitchCaseSpacing
+--rules semicolons
+--rules propertyTypes
+--rules blankLinesBetweenChainedFunctions
+--rules emptyExtensions
+--rules preferCountWhere
+--rules swiftTestingTestCaseNames
+--rules modifiersOnSameLine
+--rules noForceTryInTests
+--rules noForceUnwrapInTests
+--rules redundantThrows
+--rules redundantAsync
+--rules noGuardInTests
+--rules redundantMemberwiseInit
+--rules redundantBreak
+--rules redundantTypedThrows
+--rules preferFinalClasses

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,51 @@
+only_rules:
+  - fatal_error_message
+  - implicitly_unwrapped_optional
+  - legacy_cggeometry_functions
+  - legacy_constant
+  - legacy_constructor
+  - legacy_nsgeometry_functions
+  - unused_optional_binding
+  - unowned_variable_capture
+  - custom_rules
+
+excluded:
+  - .build
+
+indentation: 2
+
+custom_rules:
+  no_objcMembers:
+    name: "@objcMembers"
+    regex: "@objcMembers"
+    message: "Explicitly use @objc on each member you want to expose to Objective-C"
+    severity: error
+  no_direct_standard_out_logs:
+    name: "Writing log messages directly to standard out is disallowed"
+    regex: "(\\bprint|\\bdebugPrint|\\bdump|Swift\\.print|Swift\\.debugPrint|Swift\\.dump|_printChanges)\\s*\\("
+    match_kinds:
+    - identifier
+    message: "Don't commit `print(…)`, `debugPrint(…)`, `dump(…)`, or `_printChanges()` as they write to standard out in release. Either log to a dedicated logging system or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out_logs`"
+    severity: error
+  no_file_literal:
+    name: "#file is disallowed"
+    regex: "(\\b#file\\b)"
+    match_kinds:
+    - identifier
+    message: "Instead of #file, use #fileID"
+    severity: error
+  no_filepath_literal:
+    name: "#filePath is disallowed"
+    regex: "(\\b#filePath\\b)"
+    match_kinds:
+    - identifier
+    message: "Instead of #filePath, use #fileID."
+    severity: error
+  no_unchecked_sendable:
+    name: "`@unchecked Sendable` is discouraged."
+    regex: "@unchecked Sendable"
+    match_kinds:
+    - attribute.builtin
+    - typeidentifier
+    message: "Instead of using `@unchecked Sendable`, consider a safe alternative like a standard `Sendable` conformance or using `@preconcurrency import`. If you really must use `@unchecked Sendable`, you can add a `// swiftlint:disable:next no_unchecked_sendable` annotation with an explanation for how we know the type is thread-safe, and why we have to use @unchecked Sendable instead of Sendable. More explanation and suggested safe alternatives are available at https://github.com/airbnb/swift#unchecked-sendable."
+    severity: error

--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,6 @@ let package = Package(
         "StubbyMacrosPlugin",
         .product(name: "MacroTesting", package: "swift-macro-testing"),
       ]
-    )
+    ),
   ]
 )

--- a/Sources/Stubby/StubbyResponse.swift
+++ b/Sources/Stubby/StubbyResponse.swift
@@ -52,7 +52,7 @@ extension StubbyResponse {
     for url: URL,
     statusCode: Int = 200,
     httpVersion: String? = "HTTP/1.1",
-    headerFields: [String : String]? = nil,
+    headerFields: [String: String]? = nil,
     cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed
   ) throws {
     guard
@@ -73,19 +73,19 @@ extension StubbyResponse {
   }
 }
 
-// MARK: - StubbyResponse.Error + CustomNSError
+// MARK: - StubbyResponse.Error + LocalizedError, CustomNSError
 
 extension StubbyResponse.Error: LocalizedError, CustomNSError {
   var errorDescription: String? {
     switch self {
     case .invalidHTTPURLResponse:
-      return "Failed to initialize an `HTTPURLResponse`."
+      "Failed to initialize an `HTTPURLResponse`."
     }
   }
 
-  var errorUserInfo: [String : Any] {
+  var errorUserInfo: [String: Any] {
     [
-      NSLocalizedDescriptionKey: errorDescription as Any,
+      NSLocalizedDescriptionKey: errorDescription as Any
     ]
   }
 }

--- a/Sources/Stubby/StubbyURLProtocol.swift
+++ b/Sources/Stubby/StubbyURLProtocol.swift
@@ -10,7 +10,7 @@ public protocol StubbyResponseProvider {
   /// - Parameter request: The incoming `URLRequest`.
   /// - Returns: If this response provider can handle the incoming request, return `true`. Otherwise, return `false`.
   static func respondsTo(request: URLRequest) -> Bool
-  
+
   /// Provide the response for the incoming `URLRequest`.
   /// - Parameter request: The incoming `URLRequest`.
   /// - Returns: A `Result` containing either a ``StubbyResponse`` or an `Error`.
@@ -20,8 +20,6 @@ public protocol StubbyResponseProvider {
 // MARK: - StubbyURLProtocol
 
 final class StubbyURLProtocol<ResponseProvider: StubbyResponseProvider>: URLProtocol {
-
-  // MARK: Internal
 
   override class func canInit(with request: URLRequest) -> Bool {
     ResponseProvider.respondsTo(request: request)
@@ -45,6 +43,7 @@ final class StubbyURLProtocol<ResponseProvider: StubbyResponseProvider>: URLProt
       case .success(let response):
         client.urlProtocol(self, didReceive: response.urlResponse, cacheStoragePolicy: response.cacheStoragePolicy)
         client.urlProtocol(self, didLoad: response.data)
+
       case .failure(let error):
         throw error
       }

--- a/Sources/Stubby/URLSession+Stubbed.swift
+++ b/Sources/Stubby/URLSession+Stubbed.swift
@@ -13,7 +13,7 @@ extension URLSession {
   /// - Returns: A new ``URLSession`` instance.
   @available(*, deprecated, message: "Use stubbed(configuration:maintainExistingProtocolClasses:_:)")
   public static func stubbed<ResponseProvider: StubbyResponseProvider>(
-    responseProvider: ResponseProvider.Type,
+    responseProvider _: ResponseProvider.Type,
     configuration: URLSessionConfiguration = .ephemeral,
     maintainExistingProtocolClasses: Bool = false
   ) -> URLSession {
@@ -35,7 +35,7 @@ extension URLSession {
   public static func stubbed<each ResponseProvider: StubbyResponseProvider>(
     configuration: URLSessionConfiguration = .ephemeral,
     maintainExistingProtocolClasses: Bool = false,
-    _ responseProviders: repeat each ResponseProvider
+    _: repeat each ResponseProvider
   ) -> URLSession {
     if !maintainExistingProtocolClasses {
       configuration.protocolClasses = []
@@ -89,7 +89,7 @@ extension URLSession {
       configuration: configuration,
       maintainExistingProtocolClasses: maintainExistingProtocolClasses,
       [
-        .init(url: url, response: response),
+        .init(url: url, response: response)
       ]
     )
   }
@@ -126,7 +126,7 @@ private struct ResponseProvider: StubbyResponseProvider {
     stubs[stub.url] = stub
   }
 
-  static func respondsTo(request: URLRequest) -> Bool {
+  static func respondsTo(request _: URLRequest) -> Bool {
     true
   }
 

--- a/Sources/StubbyMacros/Macros.swift
+++ b/Sources/StubbyMacros/Macros.swift
@@ -3,19 +3,17 @@
 import Foundation
 import Stubby
 
-
-/*
- #Stub("https://github.com/bdbergeron/Stubby") { request in
- try .success(StubbyResponse(data: XCTUnwrap("Hello, world!".data(using: .utf8)), for: XCTUnwrap(request.url)))
- }
-
- #Stub("https://github.com") { _ in
- .failure(URLError(.unsupportedURL))
- }
- */
+// #Stub("https://github.com/bdbergeron/Stubby") { request in
+// try .success(StubbyResponse(data: XCTUnwrap("Hello, world!".data(using: .utf8)), for: XCTUnwrap(request.url)))
+// }
+//
+// #Stub("https://github.com") { _ in
+// .failure(URLError(.unsupportedURL))
+// }
 
 @freestanding(declaration)
 public macro Stub(
   _ urlString: StaticString,
-  response: (URLRequest) throws -> Result<StubbyResponse, Error>)
+  response: (URLRequest) throws -> Result<StubbyResponse, Error>
+)
   = #externalMacro(module: "StubbyMacrosPlugin", type: "StubMacro")

--- a/Sources/StubbyMacrosPlugin/Plugins.swift
+++ b/Sources/StubbyMacrosPlugin/Plugins.swift
@@ -6,6 +6,6 @@ import SwiftSyntaxMacros
 @main
 struct StubbyMacrosPlugin: CompilerPlugin {
   let providingMacros: [Macro.Type] = [
-    StubMacro.self,
+    StubMacro.self
   ]
 }

--- a/Tests/StubbyMacrosPluginTests/StubMacroTest.swift
+++ b/Tests/StubbyMacrosPluginTests/StubMacroTest.swift
@@ -12,7 +12,7 @@ final class StubMacroTest: XCTestCase {
     }
   }
 
-  func test_expansion_successResponse() throws {
+  func test_expansion_successResponse() {
     assertMacro {
       """
       #Stub(url: "https://github.com/bdbergeron/Stubby") { request in
@@ -42,7 +42,7 @@ final class StubMacroTest: XCTestCase {
     }
   }
 
-  func test_expansion_failureResponse() throws {
+  func test_expansion_failureResponse() {
     assertMacro {
       """
       #Stub(url: "https://github.com/bdbergeron/Stubby") { _ in
@@ -66,7 +66,7 @@ final class StubMacroTest: XCTestCase {
     }
   }
 
-  func test_expansion_multipleStubs() throws {
+  func test_expansion_multipleStubs() {
     assertMacro {
       """
       #Stub(url: "https://github.com/bdbergeron/Stubby") { request in
@@ -75,11 +75,11 @@ final class StubMacroTest: XCTestCase {
           for: XCTUnwrap(request.url)
         ))
       }
-      
+
       #Stub(url: "https://github.com") { _ in
         .failure(URLError(.unsupportedURL))
       }
-      
+
       #Stub(url: "https://apple.com") { _ in
         try .success(StubbyResponse(
           data: XCTUnwrap("Think different!".data(using: .utf8)),
@@ -103,7 +103,7 @@ final class StubMacroTest: XCTestCase {
         }
       }
       #endif
-      
+
       #if DEBUG
       struct __macro_local_12StubResponsefMu0_: StubbyResponseProvider {
         static let url = URL(string: "https://github.com")!
@@ -115,7 +115,7 @@ final class StubMacroTest: XCTestCase {
         }
       }
       #endif
-      
+
       #if DEBUG
       struct __macro_local_12StubResponsefMu1_: StubbyResponseProvider {
         static let url = URL(string: "https://apple.com")!
@@ -134,7 +134,7 @@ final class StubMacroTest: XCTestCase {
     }
   }
 
-  func test_expansionFailsWithInvalidURL() throws {
+  func test_expansionFailsWithInvalidURL() {
     assertMacro {
       """
       #Stub("") { request in

--- a/Tests/StubbyTests/StubbyTests.swift
+++ b/Tests/StubbyTests/StubbyTests.swift
@@ -19,9 +19,9 @@ final class StubbyTests: XCTestCase {
     XCTAssertTrue(protocolClasses.count > 1)
   }
 
-  func test_stubbyResponse_failsWithUnsupportedURLError() async {
+  func test_stubbyResponse_failsWithUnsupportedURLError() {
     let urlSession = URLSession.stubbed(url: .githubURL) { _ in
-        .failure(URLError(.unsupportedURL))
+      .failure(URLError(.unsupportedURL))
     }
   }
 
@@ -47,7 +47,7 @@ final class StubbyTests: XCTestCase {
     }
   }
 
-  func test_stubbyResponse_succeeds() async {
+  func test_stubbyResponse_succeeds() {
     let urlSession = URLSession.stubbed(url: .repoURL) { request in
       try .success(StubbyResponse(
         data: XCTUnwrap("Hello, world!".data(using: .utf8)),
@@ -99,7 +99,7 @@ final class StubbyTests: XCTestCase {
     XCTAssertEqual(String(data: githubData, encoding: .utf8), "Github")
     XCTAssertEqual(String(data: repoData, encoding: .utf8), "Hello, world!")
     do {
-      _ = try await urlSession.data(from: URL(string: "https://bradbergeron.com")!)
+      _ = try await urlSession.data(from: try XCTUnwrap(URL(string: "https://bradbergeron.com")))
       XCTFail("Should fail.")
     } catch let error as NSError {
       XCTAssertEqual(error.domain, URLError.errorDomain)

--- a/Tests/StubbyTests/TestResponseProviders.swift
+++ b/Tests/StubbyTests/TestResponseProviders.swift
@@ -6,11 +6,11 @@ import Stubby
 // MARK: - CatchallResponseProvider
 
 struct CatchallResponseProvider: StubbyResponseProvider {
-  static func respondsTo(request: URLRequest) -> Bool {
+  static func respondsTo(request _: URLRequest) -> Bool {
     true
   }
 
-  static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
+  static func response(for _: URLRequest) throws -> Result<StubbyResponse, Error> {
     .failure(URLError(.unsupportedURL))
   }
 }
@@ -30,17 +30,19 @@ struct GithubResponseProvider: StubbyResponseProvider {
   static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
     switch StubbedURL(rawValue: request.url!) {
     case .repoURL:
-      return try .success(.init(
+      try .success(.init(
         data: "Hello, world!".data(using: .utf8)!,
-        for: StubbedURL.repoURL.rawValue,
+        for: StubbedURL.repoURL.rawValue
       ))
+
     case .githubURL:
-      return try .success(.init(
+      try .success(.init(
         data: "Github".data(using: .utf8)!,
-        for: StubbedURL.githubURL.rawValue,
+        for: StubbedURL.githubURL.rawValue
       ))
+
     default:
-      return .failure(URLError(.unsupportedURL))
+      .failure(URLError(.unsupportedURL))
     }
   }
 }
@@ -51,7 +53,7 @@ struct AppleResponseProvider: StubbyResponseProvider {
   enum StubbedURL: URL, CaseIterable {
     case developers = "https://developers.apple.com"
   }
-  
+
   static func respondsTo(request: URLRequest) -> Bool {
     request.url.map(StubbedURL.contains(url:)) ?? false
   }
@@ -59,12 +61,13 @@ struct AppleResponseProvider: StubbyResponseProvider {
   static func response(for request: URLRequest) throws -> Result<StubbyResponse, Error> {
     switch StubbedURL(rawValue: request.url!) {
     case .developers:
-      return try .success(.init(
+      try .success(.init(
         data: "Apple Developer".data(using: .utf8)!,
-        for: StubbedURL.developers.rawValue,
+        for: StubbedURL.developers.rawValue
       ))
+
     default:
-      return .failure(URLError(.unsupportedURL))
+      .failure(URLError(.unsupportedURL))
     }
   }
 }


### PR DESCRIPTION
### TL;DR

Added code formatting configuration files and fixed formatting issues across the codebase.

### What changed?

- Added `.swiftformat` configuration file with comprehensive formatting rules
- Added `.swiftlint.yml` configuration file with custom linting rules
- Fixed trailing commas in `Package.swift`
- Improved code formatting across multiple files:
  - Fixed dictionary type spacing (`[String : String]` → `[String: String]`)
  - Removed redundant `return` statements in single-expression functions
  - Improved spacing and indentation
  - Fixed line breaks and trailing commas
  - Removed unnecessary comments and whitespace
  - Simplified code expressions

### How to test?

1. Run SwiftFormat on the codebase to verify it follows the new configuration
2. Run SwiftLint to ensure code adheres to the linting rules
3. Build and run tests to verify the formatting changes don't affect functionality

### Why make this change?

Standardizing code formatting improves readability and maintainability. The added configuration files ensure consistent style across the codebase and help catch potential issues early through linting rules. This change makes the codebase more professional and easier to contribute to by establishing clear formatting guidelines.