### PR TITLE
Enable StrictConcurrency and specify Swift language version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,5 +53,13 @@ let package = Package(
         .product(name: "MacroTesting", package: "swift-macro-testing"),
       ]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v5]
 )
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
+}


### PR DESCRIPTION
### TL;DR

Enable Swift 5 language version and strict concurrency checking across all targets.

### What changed?

- Added `swiftLanguageVersions: [.v5]` to explicitly specify Swift 5 as the language version
- Added the experimental feature "StrictConcurrency" to all targets' Swift settings to enforce stricter concurrency checking

### How to test?

1. Build the project to ensure it compiles successfully with strict concurrency checking enabled
2. Verify that any concurrency-related issues are properly flagged by the compiler
3. Run tests to ensure functionality remains intact with these stricter settings

### Why make this change?

Enabling strict concurrency checking helps catch potential data races and threading issues at compile time rather than runtime. This improves code safety and reliability by enforcing proper use of Swift's concurrency features across the codebase.