### PR TITLE
Add Swift 6.0 support and make ResponseProvider actor Sendable

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,0 +1,58 @@
+// swift-tools-version: 6.0
+
+import CompilerPluginSupport
+import PackageDescription
+
+let package = Package(
+  name: "Stubby",
+  platforms: [
+    .iOS(.v13),
+    .macOS(.v10_15),
+  ],
+  products: [
+    .library(name: "Stubby", targets: ["Stubby"]),
+    .library(name: "StubbyMacros", targets: ["StubbyMacros"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", .upToNextMajor(from: "0.6.4")),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", .upToNextMajor(from: "1.4.5")),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
+  ],
+  targets: [
+    .target(
+      name: "Stubby"
+    ),
+    .testTarget(
+      name: "StubbyTests",
+      dependencies: [
+        "Stubby",
+        "StubbyMacros",
+        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+      ]
+    ),
+    .target(
+      name: "StubbyMacros",
+      dependencies: [
+        "Stubby",
+        "StubbyMacrosPlugin",
+      ]
+    ),
+    .macro(
+      name: "StubbyMacrosPlugin",
+      dependencies: [
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
+      name: "StubbyMacrosPluginTests",
+      dependencies: [
+        "StubbyMacros",
+        "StubbyMacrosPlugin",
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+      ]
+    ),
+  ],
+  swiftLanguageModes: [.v5]
+)

--- a/Sources/Stubby/URLSession+Stubbed.swift
+++ b/Sources/Stubby/URLSession+Stubbed.swift
@@ -118,7 +118,7 @@ public struct Stub {
 
 // MARK: - ResponseProvider
 
-private struct ResponseProvider: StubbyResponseProvider {
+private final actor ResponseProvider: StubbyResponseProvider, Sendable {
 
   // MARK: Internal
 

--- a/Tests/StubbyTests/StubbyTests.swift
+++ b/Tests/StubbyTests/StubbyTests.swift
@@ -20,7 +20,7 @@ final class StubbyTests: XCTestCase {
   }
 
   func test_stubbyResponse_failsWithUnsupportedURLError() {
-    let urlSession = URLSession.stubbed(url: .githubURL) { _ in
+    _ = URLSession.stubbed(url: .githubURL) { _ in
       .failure(URLError(.unsupportedURL))
     }
   }
@@ -48,7 +48,7 @@ final class StubbyTests: XCTestCase {
   }
 
   func test_stubbyResponse_succeeds() {
-    let urlSession = URLSession.stubbed(url: .repoURL) { request in
+    _ = URLSession.stubbed(url: .repoURL) { request in
       try .success(StubbyResponse(
         data: XCTUnwrap("Hello, world!".data(using: .utf8)),
         for: XCTUnwrap(request.url)


### PR DESCRIPTION
### TL;DR

Added Swift 6.0 package manifest and made ResponseProvider an actor for improved concurrency safety.

### What changed?

- Added a new `Package@swift-6.0.swift` file to support Swift 6.0
- Changed `ResponseProvider` from a struct to a `final actor` and made it `Sendable` compliant
- Fixed unused variable warnings in tests by replacing variable assignments with discarded results

### How to test?

- Verify the package builds correctly with Swift 6.0
- Run the test suite to ensure all tests pass with the actor-based implementation
- Check that there are no compiler warnings related to concurrency

### Why make this change?

The actor-based implementation of `ResponseProvider` provides better thread safety in concurrent environments, which is especially important for network request handling. This change prepares the codebase for Swift 6.0's stricter concurrency model while maintaining compatibility with Swift 5 through the language mode specification in the package manifest.