### PR TITLE
Update to Swift 6, iOS 16, macOS 13 and improve concurrency safety

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
   name: "Stubby",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15),
+    .iOS(.v16),
+    .macOS(.v13),
   ],
   products: [
     .library(name: "Stubby", targets: ["Stubby"]),
@@ -55,5 +55,5 @@ let package = Package(
       ]
     ),
   ],
-  swiftLanguageModes: [.v5]
+  swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
### TL;DR

Update minimum platform requirements and Swift version while improving thread safety.

### What changed?

- Increased minimum platform requirements from iOS 13 to iOS 16 and macOS 10.15 to macOS 13
- Updated Swift language mode from v5 to v6
- Renamed `ResponseProvider` to `StubResponseProvider` for clarity
- Added `Sendable` conformance to `Stub` struct and its response closure
- Improved thread safety by using `OSAllocatedUnfairLock` instead of a simple dictionary
- Added `os` import for lock functionality

### How to test?

- Verify the package builds correctly with Swift 6
- Ensure all existing tests pass on iOS 16+ and macOS 13+
- Test concurrent stub registrations to confirm thread safety improvements

### Why make this change?

This update modernizes the codebase to take advantage of Swift 6 features and improves thread safety for concurrent environments. The higher minimum platform requirements allow us to leverage newer APIs like `OSAllocatedUnfairLock` for better performance and safety when managing stubs across multiple threads.